### PR TITLE
css3 gradients with "background" property being set multiple times only appears once in the output 

### DIFF
--- a/spec/lib/roadie/inliner_spec.rb
+++ b/spec/lib/roadie/inliner_spec.rb
@@ -61,6 +61,17 @@ describe Roadie::Inliner do
       ])
     end
 
+    it "supports properties set multiple times" do
+      # This is necessary for instance to support different browser implementations of CSS3 gradients
+      use_css 'p {
+        background:-moz-linear-gradient;
+        background:-webkit-gradient;
+        }'
+      rendering('<p></p>').should have_styling([
+        ['background', '-moz-linear-gradient'], ['background', '-webkit-gradient']
+      ])
+    end
+
     it "supports multiple selectors for the same rules" do
       use_css 'p, a { color: green; }'
       rendering('<p></p><a></a>').tap do |document|


### PR DESCRIPTION
I've written a test case which I hope isolates the problem I've come up against where you might do something like this in your css to support css3 gradients on multiple browsers:

```
p {
  background: -moz-linear-gradient(top, #1e5799 0%, #2989d8 50%, #207cca 51%, #7db9e8 100%);
  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#1e5799), color-  stop(50%,#2989d8), color-stop(51%,#207cca), color-stop(100%,#7db9e8));
}
```

but unfortunately when the styles are inlined only one of the two rules is included. So, you might get something like this in your html

```
<p style="background: -moz-linear-gradient(top, #1e5799 0%, #2989d8 50%, #207cca 51%, #7db9e8 100%)">Hello!</p>
```

I had a go at trying to figure out how to fix up but didn't make a whole lot of progress unfortunately. I got as far as figuring out that the css parser gem was outputting only one of the rules rather than both, so maybe the problem lies there?

Hope this testcase is helpful. If you can point me in the right direction to fix it that would be most awesome. Thanks!
