### PR TITLE
Duplicate Nokogiri object before converting to HTML

### DIFF
--- a/lib/roadie/inliner.rb
+++ b/lib/roadie/inliner.rb
@@ -73,7 +73,7 @@ module Roadie
       def adjust_html
         Nokogiri::HTML.parse(html).tap do |document|
           yield document
-        end.to_html
+        end.dup.to_html
       end
 
       def add_missing_structure


### PR DESCRIPTION
This prevents a segfault on OS X, or other platforms with "bad" versions
of libxml2.

This fixes #17

Best regards,

Josh & Ingemar
