### PR TITLE
Remove `Proc#bind` dependency

### DIFF
--- a/lib/roadie/action_mailer_extensions.rb
+++ b/lib/roadie/action_mailer_extensions.rb
@@ -1,7 +1,6 @@
 require 'uri'
 require 'nokogiri'
 require 'css_parser'
-require 'active_support/core_ext/proc'
 
 module Roadie
   # This module adds the Roadie functionality to ActionMailer 3 when included in ActionMailer::Base.

--- a/spec/lib/roadie/action_mailer_extensions_spec.rb
+++ b/spec/lib/roadie/action_mailer_extensions_spec.rb
@@ -47,8 +47,6 @@ module Roadie
       mailer.override_css([proc])
     end
 
-    # This spec is depend on `Proc#bind` in 'spec/lib/roadie/action_mailer_extensions_spec'.
-    # But it is deprecated in rails4.
     it "runs procs in the context of the instance" do
       new_mailer = Class.new(mailer) do
         private


### PR DESCRIPTION
This code is no longer used from ccf8ee2f.
