### PR TITLE
Prevent form pseudo-classes from being inlined

### DIFF
--- a/lib/roadie/selector.rb
+++ b/lib/roadie/selector.rb
@@ -57,6 +57,7 @@ module Roadie
       :active :focus :hover :link :target :visited
       :-ms-input-placeholder :-moz-placeholder
       :before :after
+      :enabled :disabled :checked
     ].freeze
 
     def pseudo_element?

--- a/spec/lib/roadie/selector_spec.rb
+++ b/spec/lib/roadie/selector_spec.rb
@@ -19,10 +19,13 @@ module Roadie
         p:link
         p:target
         p:visited
-        p:before
-        p:after
         p:-ms-input-placeholder
         p:-moz-placeholder
+        p:before
+        p:after
+        p:enabled
+        p:disabled
+        p:checked
       ].each do |bad_selector|
         Selector.new(bad_selector).should_not be_inlinable
       end


### PR DESCRIPTION
Added `:enabled`, `:disabled`, and `:checked` to the list of pseudo-classes that can't be inlined.

Avoids warnings like this one:

```
Roadie got error when looking for "a.button:disabled": xmlXPathCompOpEval: function disabled not found
```
