### PR TITLE
Don't default to using FilesystemProvider

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -31,7 +31,7 @@ module Roadie
     def initialize(html)
       @keep_uninlinable_css = true
       @html = html
-      @asset_providers = ProviderList.wrap(FilesystemProvider.new)
+      @asset_providers = ProviderList.empty
       @external_asset_providers = ProviderList.empty
       @css = ""
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -107,6 +107,7 @@ describe "Roadie functionality" do
         </body>
       </html>
     HTML
+    document.asset_providers << Roadie::FilesystemProvider.new
 
     result = parse_html document.transform
     expect(result).to have_styling('font-size' => '200%').at_selector('p > em')

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -27,12 +27,9 @@ module Roadie
       expect(document.external_asset_providers).to be_instance_of(ProviderList)
     end
 
-    it "defaults to having just a FilesystemProvider in the normal provider list" do
-      expect(document).to have(1).asset_providers
+    it "defaults to having no providers" do
+      expect(document).to have(0).asset_providers
       expect(document).to have(0).external_asset_providers
-
-      provider = document.asset_providers.first
-      expect(provider).to be_instance_of(FilesystemProvider)
     end
 
     it "allows changes to the normal asset providers" do


### PR DESCRIPTION
Consider defaulting the `asset_providers` to empty list instead of the `FilesystemProvider`.  That way you don't accidentally leak CSS files without intentionally adding the provider.

Also, added Rake, was missing as a dev dependency, kind of strange.  I can pull that out if desired. 