### PR TITLE
control whitespaces generated by Nokogiri

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -55,8 +55,11 @@ module Roadie
     # @see Inliner Inliner (inlines the stylesheets)
     # @see UrlRewriter UrlRewriter (rewrites URLs and makes them absolute)
     #
+    # @param [Hash] options. use `:to_html` item to pass parameters to Nokogiri.
+    #
     # @return [String] the transformed HTML
-    def transform
+    def transform options = {}
+      options[:to_html] ||= {}
       dom = Nokogiri::HTML.parse html
 
       callback before_transformation, dom
@@ -68,7 +71,7 @@ module Roadie
       callback after_transformation, dom
 
       # #dup is called since it fixed a few segfaults in certain versions of Nokogiri
-      dom.dup.to_html
+      dom.dup.to_html options[:to_html]
     end
 
     # Assign new normal asset providers. The supplied list will be wrapped in a {ProviderList} using {ProviderList.wrap}.

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -84,6 +84,16 @@ module Roadie
         document.transform
       end
 
+      it 'passes parameters to nokogiri' do
+        html = "<!DOCTYPE html>\n<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body><table><tr><td>foo</td><td>bar</td></tr></table></body></html>\n"
+        document = Document.new html
+        # normally, nokogiri puts <td> elements on separate lines but we should
+        # be able to control the whitespace behavior by passing options to
+        # transform. This way we can stop nokogiri from adding whitespace where
+        # we don't want.
+        expect(document.transform(to_html: { save_with: 0 })).to eq(html)
+      end
+
       # TODO: Remove on next major version.
       it "works on callables that don't expect more than one argument" do
         document = Document.new "<body></body>"


### PR DESCRIPTION
Some mail clients are sensible towards whitespaces. Therefore, we need
to tell Nokogiri not to put whitespace in the document. From
foundation for email's documentation:

  Make sure that there isn't any whitespace between your <td> elements,
  otherwise Thunderbird will add a gap between your block-grid
  elements.