### PR TITLE
Don't add space between table cells

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -67,8 +67,7 @@ module Roadie
 
       callback after_transformation, dom
 
-      # #dup is called since it fixed a few segfaults in certain versions of Nokogiri
-      dom.dup.to_html
+      serialize_document dom
     end
 
     # Assign new normal asset providers. The supplied list will be wrapped in a {ProviderList} using {ProviderList.wrap}.
@@ -97,6 +96,16 @@ module Roadie
 
     def rewrite_urls(dom)
       make_url_rewriter.transform_dom(dom)
+    end
+
+    def serialize_document(dom)
+      # #dup is called since it fixed a few segfaults in certain versions of Nokogiri
+      save_options = Nokogiri::XML::Node::SaveOptions
+      dom.dup.to_html(
+        save_with: (
+          save_options::NO_DECLARATION | save_options::NO_EMPTY_TAGS | save_options::AS_HTML
+        )
+      )
     end
 
     def make_url_rewriter

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -250,4 +250,25 @@ describe "Roadie functionality" do
     expect(result.at_css("body")["class"]).to eq("roadie")
     expect(result.at_css("span")).to be_nil
   end
+
+  it "does not add whitespace between table cells" do
+    document = Roadie::Document.new <<-HTML
+      <html>
+        <body>
+          <table>
+            <tr>
+              <td>One</td><td>1</td>
+            </tr>
+            <tr>
+              <td>Two</td><td>2</td>
+            </tr>
+          </table>
+        </body>
+      </html>
+    HTML
+    result = document.transform
+
+    expect(result).to include("<td>One</td><td>1</td>")
+    expect(result).to include("<td>Two</td><td>2</td>")
+  end
 end


### PR DESCRIPTION
Supersedes #122.

@everplays, would this work for you?

I experimented with the different options, but I cannot get Nokogiri to remove any indentation, just to keep it from adding extra spaces between `td` (and probably a few more examples).