### PR TITLE
Fix selector parsing by removing BOM

### DIFF
--- a/lib/roadie/stylesheet.rb
+++ b/lib/roadie/stylesheet.rb
@@ -6,6 +6,8 @@ module Roadie
   # @attr_reader [String] name the name of the stylesheet ("stylesheets/main.css", "Admin user styles", etc.). The name of the stylesheet will be visible if any errors occur.
   # @attr_reader [Array<StyleBlock>] blocks
   class Stylesheet
+    BOM = "\xEF\xBB\xBF".force_encoding('UTF-8').freeze
+
     attr_reader :name, :blocks
 
     # Parses the CSS string into a {StyleBlock}s and stores it.
@@ -14,7 +16,7 @@ module Roadie
     # @param [String] css
     def initialize(name, css)
       @name = name
-      @blocks = parse_blocks(css)
+      @blocks = parse_blocks(css.sub(BOM, ""))
     end
 
     # @yield [selector, properties]


### PR DESCRIPTION
Selectors are valid but parsing fails due to extra bytes in a string.
Those extra bytes are added by a sass when compiling files.

https://www.w3.org/International/questions/qa-byte-order-mark

> In HTML5 browsers are required to recognize the UTF-8 BOM and use it to detect the encoding of the page, and recent versions of major browsers handle the BOM as expected when used for UTF-8 encoded pages.

This fix eliminates unwanted warnings.