### PR TITLE
Add support for Nokogiri 1.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,18 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
   - jruby
   - rbx
-
 matrix:
   allow_failures:
-    # Rubinius has a lot of trouble and no large following, so I'm going to
+    # Rubinius and JRuby have a lot of trouble and no large following, so I'm going to
     # allow failures on it until it gets more stable on Travis / Real Life(tm).
     # Let me know if you need it. Patches are welcome!
+    - rvm: jruby
     - rvm: rbx
+    - rvm: 2.4.0
   fast_finish: true
-
 cache: bundler
 bundler_args: --without guard
 script: "rake"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v3.2.0...master)
 
-* Nothing yet.
+* Enhancements
+  * Support Nokogiri 1.7.x.
 
 ### 3.2.0
 

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9"
 
-  s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.7.0'
+  s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.8.0'
   s.add_dependency 'css_parser', '~> 1.4.5'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This PR relaxes the version requirement of Nokogiri to support 1.7.x which has recently been released. 