### PR TITLE
Support Nokogiri 1.8

### DIFF
--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9"
 
-  s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.8.0'
+  s.add_dependency 'nokogiri', '~> 1.5'
   s.add_dependency 'css_parser', '~> 1.4.5'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Loosen conservative dependency. Expect a stable API up to 2.0.

Prefer to allow apps to drive the Nokogiri upgrade path since it's
such a common, core dependency that affects dependency resolution
of many other libraries.

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#180--2017-06-04