### PR TITLE
Add option for saving Roadie documents as XHTML

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -27,6 +27,8 @@ module Roadie
     # Should CSS that cannot be inlined be kept in a new `<style>` element in `<head>`?
     attr_accessor :keep_uninlinable_css
 
+    attr_accessor :save_as_xhtml
+
     # @param [String] html the input HTML
     def initialize(html)
       @keep_uninlinable_css = true
@@ -103,7 +105,9 @@ module Roadie
       save_options = Nokogiri::XML::Node::SaveOptions
       dom.dup.to_html(
         save_with: (
-          save_options::NO_DECLARATION | save_options::NO_EMPTY_TAGS | save_options::AS_HTML
+          save_options::NO_DECLARATION |
+          save_options::NO_EMPTY_TAGS |
+          (save_as_xhtml ? save_options::AS_XHTML : save_options::AS_HTML)
         )
       )
     end

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -59,6 +59,12 @@ module Roadie
       expect(document.external_asset_providers).to eq(old_list)
     end
 
+    it "allows changes save_as_xhtml flag" do
+      document.save_as_xhtml = true
+
+      expect(document.save_as_xhtml).to be(true)
+    end
+
     it "can store callbacks for inlining" do
       callable = double "Callable"
 
@@ -97,6 +103,15 @@ module Roadie
           raise "Oops" unless second
         }
         expect { document.transform }.to_not raise_error
+      end
+
+      context 'when save as xhtml flag is present' do
+        it "does not escape some HTML symbols" do
+          document = Document.new "<body><a href='https://google.com/{{hello}}'>Hello</body>"
+          document.save_as_xhtml = true
+
+          expect(document.transform).to include("{{hello}}")
+        end
       end
     end
   end


### PR DESCRIPTION
I think it makes sense to be able to specify the format of the saved file.
Use case:
  We do additional template processing on our emails via handlebars templates.