### PR TITLE
Allows user to set document to be partial and avoid header section

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -30,6 +30,8 @@ module Roadie
     # The mode to generate markup in. Valid values are `:html` (default) and `:xhtml`.
     attr_reader :mode
 
+    #Allow for partial which will not have <!DOCTYPE html!><head>... added
+    attr_reader :partial
     # @param [String] html the input HTML
     def initialize(html)
       @keep_uninlinable_css = true
@@ -38,6 +40,7 @@ module Roadie
       @external_asset_providers = ProviderList.empty
       @css = ""
       @mode = :html
+      @partial = false
     end
 
     # Append additional CSS to the document's internal stylesheet.
@@ -61,8 +64,7 @@ module Roadie
     #
     # @return [String] the transformed HTML
     def transform
-      dom = Nokogiri::HTML.parse html
-
+      partial ? (dom = Nokogiri::HTML::DocumentFragment.parse html) : (dom = Nokogiri::HTML.parse html)
       callback before_transformation, dom
 
       improve dom
@@ -106,7 +108,7 @@ module Roadie
     end
 
     def improve(dom)
-      MarkupImprover.new(dom, html).improve
+      MarkupImprover.new(dom, html).improve unless partial
     end
 
     def inline(dom)


### PR DESCRIPTION
Being able to use Roadie on partials without monkey patching it would be a huge improvement. 

If you have an email with partials that you're not rendering until later in the process, they automatically get a <head> section added using Roadie which cuts the email of where the partials is rendered. 

This feature mimics the style of keep_uninlineable_css and therefor does not effect users not in need of this update, but does save users who like partials. 