### PR TITLE
Support partial HTML documents

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -13,6 +13,8 @@ module Roadie
   # The internal stylesheet is used last and gets the highest priority. The
   # rest is used in the same order as browsers are supposed to use them.
   #
+  # The execution methods are {#transform} and {#transform_partial}.
+  #
   # @attr [#call] before_transformation Callback to call just before {#transform}ation begins. Will be called with the parsed DOM tree and the {Document} instance.
   # @attr [#call] after_transformation Callback to call just before {#transform}ation is completed. Will be called with the current DOM tree and the {Document} instance.
   class Document
@@ -46,18 +48,21 @@ module Roadie
       @css << "\n\n" << new_css
     end
 
-    # Transform the input HTML and returns the processed HTML.
+    # Transform the input HTML as a full document and returns the processed
+    # HTML.
     #
     # Before the transformation begins, the {#before_transformation} callback
     # will be called with the parsed HTML tree and the {Document} instance, and
     # after all work is complete the {#after_transformation} callback will be
     # invoked in the same way.
     #
-    # Most of the work is delegated to other classes. A list of them can be seen below.
+    # Most of the work is delegated to other classes. A list of them can be
+    # seen below.
     #
     # @see MarkupImprover MarkupImprover (improves the markup of the DOM)
     # @see Inliner Inliner (inlines the stylesheets)
     # @see UrlRewriter UrlRewriter (rewrites URLs and makes them absolute)
+    # @see #transform_partial Transforms partial documents (fragments)
     #
     # @return [String] the transformed HTML
     def transform
@@ -66,7 +71,40 @@ module Roadie
       callback before_transformation, dom
 
       improve dom
-      inline dom
+      inline dom, keep_uninlinable_in: :head
+      rewrite_urls dom
+
+      callback after_transformation, dom
+
+      serialize_document dom
+    end
+
+    # Transform the input HTML as a HTML fragment/partial and returns the
+    # processed HTML.
+    #
+    # Before the transformation begins, the {#before_transformation} callback
+    # will be called with the parsed HTML tree and the {Document} instance, and
+    # after all work is complete the {#after_transformation} callback will be
+    # invoked in the same way.
+    #
+    # The main difference between this and {#transform} is that this does not
+    # treat the HTML as a full document and does not try to fix it by adding
+    # doctypes, {<head>} elements, etc.
+    #
+    # Most of the work is delegated to other classes. A list of them can be
+    # seen below.
+    #
+    # @see Inliner Inliner (inlines the stylesheets)
+    # @see UrlRewriter UrlRewriter (rewrites URLs and makes them absolute)
+    # @see #transform Transforms full documents
+    #
+    # @return [String] the transformed HTML
+    def transform_partial
+      dom = Nokogiri::HTML.fragment html
+
+      callback before_transformation, dom
+
+      inline dom, keep_uninlinable_in: :root
       rewrite_urls dom
 
       callback after_transformation, dom
@@ -109,9 +147,12 @@ module Roadie
       MarkupImprover.new(dom, html).improve
     end
 
-    def inline(dom)
+    def inline(dom, keep_uninlinable_in:)
       dom_stylesheets = AssetScanner.new(dom, asset_providers, external_asset_providers).extract_css
-      Inliner.new(dom_stylesheets + [stylesheet], dom).inline(keep_uninlinable_css)
+      Inliner.new(dom_stylesheets + [stylesheet], dom).inline(
+        keep_uninlinable_css: keep_uninlinable_css,
+        keep_uninlinable_in: keep_uninlinable_in,
+      )
     end
 
     def rewrite_urls(dom)

--- a/lib/roadie/inliner.rb
+++ b/lib/roadie/inliner.rb
@@ -24,13 +24,17 @@ module Roadie
 
     # Start the inlining, mutating the DOM tree.
     #
-    # @param [true, false] keep_extra_blocks
+    # @param [true, false] keep_uninlinable_css
+    # @param [:root, :head] keep_uninlinable_in
     # @return [nil]
-    def inline(keep_extra_blocks = true)
+    def inline(keep_uninlinable_css: true, keep_uninlinable_in: :head)
       style_map, extra_blocks = consume_stylesheets
 
       apply_style_map(style_map)
-      add_styles_to_head(extra_blocks) if keep_extra_blocks
+
+      if keep_uninlinable_css
+        add_uninlinable_styles(keep_uninlinable_in, extra_blocks)
+      end
 
       nil
     end
@@ -89,21 +93,31 @@ module Roadie
       nil
     end
 
-    def add_styles_to_head(blocks)
-      unless blocks.empty?
-        create_style_element(blocks, find_head)
-      end
+    def add_uninlinable_styles(parent, blocks)
+      return if blocks.empty?
+
+      parent_node =
+        case parent
+        when :head
+          find_head
+        when :root
+          dom
+        else
+          raise ArgumentError, "Parent must be either :head or :root. Was #{parent.inspect}"
+        end
+
+      create_style_element(blocks, parent_node)
     end
 
     def find_head
       dom.at_xpath('html/head')
     end
 
-    def create_style_element(style_blocks, head)
-      return unless head
-      element = Nokogiri::XML::Node.new("style", head.document)
+    def create_style_element(style_blocks, parent)
+      return unless parent
+      element = Nokogiri::XML::Node.new("style", parent.document)
       element.content = style_blocks.join("\n")
-      head.add_child(element)
+      parent.add_child(element)
     end
 
     # @api private

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,274 +1,477 @@
 require 'spec_helper'
 
 describe "Roadie functionality" do
-  def parse_html(html)
-    Nokogiri::HTML.parse(html)
-  end
-
-  it "adds missing structure" do
-    html = "<h1>Hello world!</h1>".encode("Shift_JIS")
-    document = Roadie::Document.new(html)
-    result = document.transform
-
-    unless defined?(JRuby)
-      # JRuby has a bug that makes DTD manipulation impossible
-      # See Nokogiri bugs #984 and #985
-      # https://github.com/sparklemotion/nokogiri/issues/984
-      # https://github.com/sparklemotion/nokogiri/issues/985
-      expect(result).to include("<!DOCTYPE html>")
+  describe "on full documents" do
+    def parse_html(html)
+      Nokogiri::HTML.parse(html)
     end
 
-    expect(result).to include("<html>")
-    expect(result).to include("<head>")
-    expect(result).to include("<body>")
+    it "adds missing structure" do
+      html = "<h1>Hello world!</h1>".encode("Shift_JIS")
+      document = Roadie::Document.new(html)
+      result = document.transform
 
-    expect(result).to include("<meta")
-    expect(result).to include("text/html; charset=Shift_JIS")
-  end
+      unless defined?(JRuby)
+        # JRuby has a bug that makes DTD manipulation impossible
+        # See Nokogiri bugs #984 and #985
+        # https://github.com/sparklemotion/nokogiri/issues/984
+        # https://github.com/sparklemotion/nokogiri/issues/985
+        expect(result).to include("<!DOCTYPE html>")
+      end
 
-  it "inlines given css" do
-    document = Roadie::Document.new <<-HTML
-      <html>
+      expect(result).to include("<html>")
+      expect(result).to include("<head>")
+      expect(result).to include("<body>")
+
+      expect(result).to include("<meta")
+      expect(result).to include("text/html; charset=Shift_JIS")
+    end
+
+    it "inlines given css" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <head>
+            <title>Hello world!</title>
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+      document.add_css <<-CSS
+        em { color: red; }
+        h1 { text-align: center; }
+      CSS
+
+      result = parse_html document.transform
+      expect(result).to have_styling('text-align' => 'center').at_selector('h1')
+      expect(result).to have_styling('color' => 'red').at_selector('p > em')
+    end
+
+    it "stores styles that cannot be inlined in the <head>" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+      css = <<-CSS
+        em:hover { color: red; }
+        p:fung-shuei { color: spirit; }
+      CSS
+      document.add_css css
+      expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
+
+      result = parse_html document.transform
+      expect(result).to have_selector("html > head > style")
+
+      styles = result.at_css("html > head > style").text
+      expect(styles).to include Roadie::Stylesheet.new("", css).to_s
+    end
+
+    it "can be configured to skip styles that cannot be inlined" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+      css = <<-CSS
+        em:hover { color: red; }
+        p:fung-shuei { color: spirit; }
+      CSS
+      document.add_css css
+      document.keep_uninlinable_css = false
+
+      expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
+
+      result = parse_html document.transform
+      expect(result).to_not have_selector("html > head > style")
+    end
+
+    it "inlines css from disk" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Hello world!</title>
+            <link rel="stylesheet" href="/spec/fixtures/big_em.css">
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+
+      result = parse_html document.transform
+      expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
+    end
+
+    it "crashes when stylesheets cannot be found, unless using NullProvider" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <link rel="stylesheet" href="/spec/fixtures/does_not_exist.css">
+          </head>
+          <body>
+          </body>
+        </html>
+      HTML
+
+      expect { document.transform }.to raise_error(Roadie::CssNotFound, /does_not_exist\.css/)
+
+      document.asset_providers << Roadie::NullProvider.new
+      expect { document.transform }.to_not raise_error
+    end
+
+    it "ignores external css if no external providers are added" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Hello world!</title>
+            <link rel="stylesheet" href="http://example.com/big_em.css">
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+
+      document.external_asset_providers = []
+
+      result = parse_html document.transform
+      expect(result).to have_selector('head > link')
+      expect(result).to have_styling([]).at_selector('p > em')
+    end
+
+    it "inlines external css if configured" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Hello world!</title>
+            <link rel="stylesheet" href="http://example.com/big_em.css">
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+            <p>Check out these <em>awesome</em> prices!</p>
+          </body>
+        </html>
+      HTML
+
+      document.external_asset_providers = TestProvider.new(
+        "http://example.com/big_em.css" => "em { font-size: 200%; }"
+      )
+
+      result = parse_html document.transform
+      expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
+      expect(result).to_not have_selector('head > link')
+    end
+
+    it "does not inline the same properties several times" do
+      document = Roadie::Document.new <<-HTML
         <head>
-          <title>Hello world!</title>
+          <link rel="stylesheet" href="hello.css">
         </head>
         <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
+          <p class="hello world">Hello world</p>
         </body>
-      </html>
-    HTML
-    document.add_css <<-CSS
-      em { color: red; }
-      h1 { text-align: center; }
-    CSS
+      HTML
 
-    result = parse_html document.transform
-    expect(result).to have_styling('text-align' => 'center').at_selector('h1')
-    expect(result).to have_styling('color' => 'red').at_selector('p > em')
+      document.asset_providers = TestProvider.new("hello.css" => <<-CSS)
+        p { color: red; }
+        .hello { color: red; }
+        .world { color: red; }
+      CSS
+
+      result = parse_html document.transform
+      expect(result).to have_styling([
+        ['color', 'red']
+      ]).at_selector('p')
+    end
+
+    it "makes URLs absolute" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              body { background: url("/assets/bg-abcdef1234567890.png"); }
+            </style>
+            <link rel="stylesheet" href="/style.css">
+          </head>
+          <body>
+            <a href="/about_us"><img src="/assets/about_us-abcdef1234567890.png" alt="About us"></a>
+          </body>
+        </html>
+      HTML
+
+      document.asset_providers = TestProvider.new(
+        "/style.css" => "a { background: url(/assets/link-abcdef1234567890.png); }"
+      )
+      document.url_options = {host: "myapp.com", scheme: "https", path: "rails/app/"}
+      result = parse_html document.transform
+
+      expect(result.at_css("a")["href"]).to eq("https://myapp.com/rails/app/about_us")
+
+      expect(result.at_css("img")["src"]).to eq("https://myapp.com/rails/app/assets/about_us-abcdef1234567890.png")
+
+      expect(result).to have_styling(
+        "background" => 'url("https://myapp.com/rails/app/assets/bg-abcdef1234567890.png")'
+      ).at_selector("body")
+
+      expect(result).to have_styling(
+        "background" => 'url(https://myapp.com/rails/app/assets/link-abcdef1234567890.png)'
+      ).at_selector("a")
+    end
+
+    it "allows custom callbacks during inlining" do
+      document = Roadie::Document.new <<-HTML
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <span>Hello world</span>
+          </body>
+        </html>
+      HTML
+
+      document.before_transformation = proc { |dom| dom.at_css("body")["class"] = "roadie" }
+      document.after_transformation = proc { |dom| dom.at_css("span").remove }
+
+      result = parse_html document.transform
+      expect(result.at_css("body")["class"]).to eq("roadie")
+      expect(result.at_css("span")).to be_nil
+    end
+
+    it "does not add whitespace between table cells" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <body>
+            <table>
+              <tr>
+                <td>One</td><td>1</td>
+              </tr>
+              <tr>
+                <td>Two</td><td>2</td>
+              </tr>
+            </table>
+          </body>
+        </html>
+      HTML
+      result = document.transform
+
+      expect(result).to include("<td>One</td><td>1</td>")
+      expect(result).to include("<td>Two</td><td>2</td>")
+    end
   end
 
-  it "stores styles that cannot be inlined in the <head>" do
-    document = Roadie::Document.new <<-HTML
-      <html>
-        <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
-        </body>
-      </html>
-    HTML
-    css = <<-CSS
-      em:hover { color: red; }
-      p:fung-shuei { color: spirit; }
-    CSS
-    document.add_css css
-    expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
+  describe "on partial documents" do
+    def parse_html(html)
+      Nokogiri::HTML.fragment(html)
+    end
 
-    result = parse_html document.transform
-    expect(result).to have_selector("html > head > style")
+    it "does not add structure" do
+      html = "<h1>Hello world!</h1>".encode("Shift_JIS")
+      document = Roadie::Document.new(html)
 
-    styles = result.at_css("html > head > style").text
-    expect(styles).to include Roadie::Stylesheet.new("", css).to_s
-  end
+      result = document.transform_partial
 
-  it "can be configured to skip styles that cannot be inlined" do
-    document = Roadie::Document.new <<-HTML
-      <html>
-        <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
-        </body>
-      </html>
-    HTML
-    css = <<-CSS
-      em:hover { color: red; }
-      p:fung-shuei { color: spirit; }
-    CSS
-    document.add_css css
-    document.keep_uninlinable_css = false
+      expect(result).to eq(html)
+    end
 
-    expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
+    it "inlines given css" do
+      document = Roadie::Document.new <<-HTML
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
+      document.add_css <<-CSS
+        em { color: red; }
+        h1 { text-align: center; }
+      CSS
 
-    result = parse_html document.transform
-    expect(result).to_not have_selector("html > head > style")
-  end
+      result = parse_html document.transform_partial
+      expect(result).to have_styling('text-align' => 'center').at_selector('h1')
+      expect(result).to have_styling('color' => 'red').at_selector('p > em')
+    end
 
-  it "inlines css from disk" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Hello world!</title>
-          <link rel="stylesheet" href="/spec/fixtures/big_em.css">
-        </head>
-        <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
-        </body>
-      </html>
-    HTML
+    it "stores styles that cannot be inlined in a new <style> element" do
+      document = Roadie::Document.new <<-HTML
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
+      css = <<-CSS
+        em:hover { color: red; }
+        p:fung-shuei { color: spirit; }
+      CSS
+      document.add_css css
+      expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
 
-    result = parse_html document.transform
-    expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
-  end
+      result = parse_html document.transform_partial
+      expect(result).to have_xpath("./style")
 
-  it "crashes when stylesheets cannot be found, unless using NullProvider" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <link rel="stylesheet" href="/spec/fixtures/does_not_exist.css">
-        </head>
-        <body>
-        </body>
-      </html>
-    HTML
+      styles = result.at_xpath("./style").text
+      expect(styles).to include Roadie::Stylesheet.new("", css).to_s
+    end
 
-    expect { document.transform }.to raise_error(Roadie::CssNotFound, /does_not_exist\.css/)
+    it "can be configured to skip styles that cannot be inlined" do
+      document = Roadie::Document.new <<-HTML
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
+      css = <<-CSS
+        em:hover { color: red; }
+        p:fung-shuei { color: spirit; }
+      CSS
+      document.add_css css
+      document.keep_uninlinable_css = false
 
-    document.asset_providers << Roadie::NullProvider.new
-    expect { document.transform }.to_not raise_error
-  end
+      expect(Roadie::Utils).to receive(:warn).with(/fung-shuei/)
 
-  it "ignores external css if no external providers are added" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Hello world!</title>
-          <link rel="stylesheet" href="http://example.com/big_em.css">
-        </head>
-        <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
-        </body>
-      </html>
-    HTML
+      result = parse_html document.transform_partial
+      expect(result).to_not have_xpath("./style")
+    end
 
-    document.external_asset_providers = []
+    it "inlines css from disk" do
+      document = Roadie::Document.new <<-HTML
+        <link rel="stylesheet" href="/spec/fixtures/big_em.css">
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
 
-    result = parse_html document.transform
-    expect(result).to have_selector('head > link')
-    expect(result).to have_styling([]).at_selector('p > em')
-  end
+      result = parse_html document.transform_partial
+      expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
+    end
 
-  it "inlines external css if configured" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Hello world!</title>
-          <link rel="stylesheet" href="http://example.com/big_em.css">
-        </head>
-        <body>
-          <h1>Hello world!</h1>
-          <p>Check out these <em>awesome</em> prices!</p>
-        </body>
-      </html>
-    HTML
+    it "crashes when stylesheets cannot be found, unless using NullProvider" do
+      document = Roadie::Document.new <<-HTML
+        <link rel="stylesheet" href="/spec/fixtures/does_not_exist.css">
+      HTML
 
-    document.external_asset_providers = TestProvider.new(
-      "http://example.com/big_em.css" => "em { font-size: 200%; }"
-    )
+      expect { document.transform_partial }.to raise_error(Roadie::CssNotFound, /does_not_exist\.css/)
 
-    result = parse_html document.transform
-    expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
-    expect(result).to_not have_selector('head > link')
-  end
+      document.asset_providers << Roadie::NullProvider.new
+      expect { document.transform_partial }.to_not raise_error
+    end
 
-  it "does not inline the same properties several times" do
-    document = Roadie::Document.new <<-HTML
-      <head>
+    it "ignores external css if no external providers are added" do
+      document = Roadie::Document.new <<-HTML
+        <link rel="stylesheet" href="http://example.com/big_em.css">
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
+
+      document.external_asset_providers = []
+
+      result = parse_html document.transform_partial
+      expect(result).to have_xpath('./link')
+      expect(result).to have_styling([]).at_selector('p > em')
+    end
+
+    it "inlines external css if configured" do
+      document = Roadie::Document.new <<-HTML
+        <link rel="stylesheet" href="http://example.com/big_em.css">
+        <h1>Hello world!</h1>
+        <p>Check out these <em>awesome</em> prices!</p>
+      HTML
+
+      document.external_asset_providers = TestProvider.new(
+        "http://example.com/big_em.css" => "em { font-size: 200%; }"
+      )
+
+      result = parse_html document.transform_partial
+      expect(result).to have_styling('font-size' => '200%').at_selector('p > em')
+      expect(result).to_not have_xpath('./link')
+    end
+
+    it "does not inline the same properties several times" do
+      document = Roadie::Document.new <<-HTML
         <link rel="stylesheet" href="hello.css">
-      </head>
-      <body>
         <p class="hello world">Hello world</p>
-      </body>
-    HTML
+      HTML
 
-    document.asset_providers = TestProvider.new("hello.css" => <<-CSS)
-      p { color: red; }
-      .hello { color: red; }
-      .world { color: red; }
-    CSS
+      document.asset_providers = TestProvider.new("hello.css" => <<-CSS)
+        p { color: red; }
+        .hello { color: red; }
+        .world { color: red; }
+      CSS
 
-    result = parse_html document.transform
-    expect(result).to have_styling([
-      ['color', 'red']
-    ]).at_selector('p')
-  end
+      result = parse_html document.transform_partial
+      expect(result).to have_styling([
+        ['color', 'red']
+      ]).at_selector('p')
+    end
 
-  it "makes URLs absolute" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <style>
-            body { background: url("/assets/bg-abcdef1234567890.png"); }
-          </style>
-          <link rel="stylesheet" href="/style.css">
-        </head>
-        <body>
-          <a href="/about_us"><img src="/assets/about_us-abcdef1234567890.png" alt="About us"></a>
-        </body>
-      </html>
-    HTML
+    it "makes URLs absolute" do
+      document = Roadie::Document.new <<-HTML
+        <style>
+          div { background: url("/assets/bg-abcdef1234567890.png"); }
+        </style>
+        <link rel="stylesheet" href="/style.css">
+        <div>
+          <a href="/about_us">
+            <img src="/assets/about_us-abcdef1234567890.png" alt="About us">
+          </a>
+        </div>
+      HTML
 
-    document.asset_providers = TestProvider.new(
-      "/style.css" => "a { background: url(/assets/link-abcdef1234567890.png); }"
-    )
-    document.url_options = {host: "myapp.com", scheme: "https", path: "rails/app/"}
-    result = parse_html document.transform
+      document.asset_providers = TestProvider.new(
+        "/style.css" => "a { background: url(/assets/link-abcdef1234567890.png); }"
+      )
+      document.url_options = {host: "myapp.com", scheme: "https", path: "rails/app/"}
+      result = parse_html document.transform_partial
 
-    expect(result.at_css("a")["href"]).to eq("https://myapp.com/rails/app/about_us")
+      expect(result.at_css("a")["href"]).to eq("https://myapp.com/rails/app/about_us")
 
-    expect(result.at_css("img")["src"]).to eq("https://myapp.com/rails/app/assets/about_us-abcdef1234567890.png")
+      expect(result.at_css("img")["src"]).to eq(
+        "https://myapp.com/rails/app/assets/about_us-abcdef1234567890.png"
+      )
 
-    expect(result).to have_styling(
-      "background" => 'url("https://myapp.com/rails/app/assets/bg-abcdef1234567890.png")'
-    ).at_selector("body")
+      expect(result).to have_styling(
+        "background" => 'url("https://myapp.com/rails/app/assets/bg-abcdef1234567890.png")'
+      ).at_selector("div")
 
-    expect(result).to have_styling(
-      "background" => 'url(https://myapp.com/rails/app/assets/link-abcdef1234567890.png)'
-    ).at_selector("a")
-  end
+      expect(result).to have_styling(
+        "background" => 'url(https://myapp.com/rails/app/assets/link-abcdef1234567890.png)'
+      ).at_selector("a")
+    end
 
-  it "allows custom callbacks during inlining" do
-    document = Roadie::Document.new <<-HTML
-      <!DOCTYPE html>
-      <html>
-        <body>
-          <span>Hello world</span>
-        </body>
-      </html>
-    HTML
+    it "allows custom callbacks during inlining" do
+      document = Roadie::Document.new <<-HTML
+        <p><span>Hello world</span></p>
+      HTML
 
-    document.before_transformation = proc { |dom| dom.at_css("body")["class"] = "roadie" }
-    document.after_transformation = proc { |dom| dom.at_css("span").remove }
+      document.before_transformation = proc { |dom| dom.at_css("p")["class"] = "roadie" }
+      document.after_transformation = proc { |dom| dom.at_css("span").remove }
 
-    result = parse_html document.transform
-    expect(result.at_css("body")["class"]).to eq("roadie")
-    expect(result.at_css("span")).to be_nil
-  end
+      result = parse_html document.transform_partial
+      expect(result.at_css("p")["class"]).to eq("roadie")
+      expect(result.at_css("span")).to be_nil
+    end
 
-  it "does not add whitespace between table cells" do
-    document = Roadie::Document.new <<-HTML
-      <html>
-        <body>
-          <table>
-            <tr>
-              <td>One</td><td>1</td>
-            </tr>
-            <tr>
-              <td>Two</td><td>2</td>
-            </tr>
-          </table>
-        </body>
-      </html>
-    HTML
-    result = document.transform
+    it "does not add whitespace between table cells" do
+      document = Roadie::Document.new <<-HTML
+        <table>
+          <tr>
+            <td>One</td><td>1</td>
+          </tr>
+          <tr>
+            <td>Two</td><td>2</td>
+          </tr>
+        </table>
+      HTML
+      result = document.transform_partial
 
-    expect(result).to include("<td>One</td><td>1</td>")
-    expect(result).to include("<td>Two</td><td>2</td>")
+      expect(result).to include("<td>One</td><td>1</td>")
+      expect(result).to include("<td>Two</td><td>2</td>")
+    end
   end
 end

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -119,10 +119,43 @@ module Roadie
 
       context "in HTML mode" do
         it "does not escape curly braces" do
-          document = Document.new "<body><a href='https://google.com/{{hello}}'>Hello</body>"
+          document = Document.new "<body><a href='https://google.com/{{hello}}'>Hello</a></body>"
           document.mode = :xhtml
 
           expect(document.transform).to include("{{hello}}")
+        end
+      end
+    end
+
+    describe "partial transforming" do
+      it "runs the before and after callbacks" do
+        document = Document.new "<p></p>"
+        before = ->{}
+        after = ->{}
+        document.before_transformation = before
+        document.after_transformation = after
+
+        expect(before).to receive(:call).with(
+          instance_of(Nokogiri::HTML::DocumentFragment),
+          document,
+        ).ordered
+
+        expect(Inliner).to receive(:new).ordered.and_return double.as_null_object
+
+        expect(after).to receive(:call).with(
+          instance_of(Nokogiri::HTML::DocumentFragment),
+          document,
+        ).ordered
+
+        document.transform_partial
+      end
+
+      context "in HTML mode" do
+        it "does not escape curly braces" do
+          document = Document.new "<a href='https://google.com/{{hello}}'>Hello</a>"
+          document.mode = :xhtml
+
+          expect(document.transform_partial).to include("{{hello}}")
         end
       end
     end

--- a/spec/lib/roadie/inliner_spec.rb
+++ b/spec/lib/roadie/inliner_spec.rb
@@ -219,8 +219,23 @@ module Roadie
               <body><p></p></body>
             </html>
           "
-          Inliner.new([stylesheet], dom).inline(false)
+          Inliner.new([stylesheet], dom).inline(keep_uninlinable_css: false)
           expect(dom).to_not have_selector("head > style")
+        end
+
+        it "puts the <style> element at the root when told so" do
+          stylesheet = use_css 'a:hover { color: red; }'
+          dom = Nokogiri::HTML.fragment("
+            <a></a>
+          ")
+
+          Inliner.new([stylesheet], dom).inline(
+            keep_uninlinable_css: true,
+            keep_uninlinable_in: :root,
+          )
+
+          expect(dom).to have_xpath("./a")
+          expect(dom).to have_xpath("./style")
         end
       end
     end

--- a/spec/support/have_selector_matcher.rb
+++ b/spec/support/have_selector_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_selector do |selector|
   match { |document| !document.css(selector).empty? }
-  failure_message { "expected document to #{name_to_sentence}#{to_sentence selector}"}
-  failure_message_when_negated { "expected document to not #{name_to_sentence}#{to_sentence selector}"}
+  failure_message { "expected document to have selector #{selector.inspect}"}
+  failure_message_when_negated { "expected document to not have selector #{selector.inspect}"}
 end
 

--- a/spec/support/have_xpath_matcher.rb
+++ b/spec/support/have_xpath_matcher.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :have_xpath do |xpath|
+  match { |document| !document.xpath(xpath).empty? }
+  failure_message { "expected document to have xpath #{xpath.inspect}"}
+  failure_message_when_negated { "expected document to not have xpath #{xpath.inspect}"}
+end
+


### PR DESCRIPTION
Supersedes #146 and #115.

`Document` is still only one class, but there are two different transformation methods:
* `transform` (same as before; full documents)
* `transform_partial` (transforms the HTML as a partial document)

I still think the code in #115 was a slightly better design, but this is a smaller change that is still "good enough", I hope.

I'm interested in getting someone testing this out before I merge and cut a new release. Is @andfx or @FridaShjoholm interested in testing this?

## Left to do

- [ ] Update README and Changelog
- [ ] Verify docs looks okay