### PR TITLE
Rework charset selection in NetHttpProvider

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 * Enhancements
   * Allow transforming to XHTML instead of HTML - [Zhivko Draganov](https://github.com/zdraganov) (#144).
+* Bug fixes:
+  * Apply correct string encoding / charset in `NetHttpProvider` - [Jeremy Nagel](https://github.com/jeznag) (#152).
 
 ### 3.2.2
 

--- a/lib/roadie/net_http_provider.rb
+++ b/lib/roadie/net_http_provider.rb
@@ -34,16 +34,7 @@ module Roadie
     def find_stylesheet!(url)
       response = download(url)
       if response.kind_of? Net::HTTPSuccess
-        # Make sure we respect encoding because Net:HTTP will encode body as ASCII by default
-        # which will break if the response is actually UTF-8
-        supplied_charset = response.type_params['charset']
-        body = if supplied_charset
-          response.body.force_encoding(supplied_charset)
-        else
-          response.body
-        end
-
-        Stylesheet.new(url, body)
+        Stylesheet.new(url, response_body(response))
       else
         raise CssNotFound.new(url, "Server returned #{response.code}: #{truncate response.body}", self)
       end
@@ -94,6 +85,21 @@ module Roadie
         string[0, 49] + "…"
       else
         string
+      end
+    end
+
+    def response_body(response)
+      # Make sure we respect encoding because Net:HTTP will encode body as ASCII by default
+      # which will break if the response is not compatible.
+      supplied_charset = response.type_params['charset']
+      body = response.body
+
+      if supplied_charset
+        body.force_encoding(supplied_charset).encode!("UTF-8")
+      else
+        # Default to UTF-8 when server does not specify encoding as that is the
+        # most common charset.
+        body.force_encoding("UTF-8")
       end
     end
   end


### PR DESCRIPTION
Follow-up from #152, which was not entirely correct.

- Add entry to Changelog.
- Extract private method.
- Default to UTF-8 when server does not specify an encoding.
- Actually re-encode the input to a matching charset (UTF-8) before sending it off to Stylesheet.
- Make tests actually fail when implementation does not do the correct thing. They were false positives before due to String mutations inside the tests and tautological assertions.

I still give you credit for the fix, @jeznag. Thank you for your contribution! :heart: 