### PR TITLE
Make roadie compatible with frozen string literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.5
   - jruby
   - rbx
+env:
+  - RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
+  - RUBYOPT=""
 before_install:
   - gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
   - gem install bundler
@@ -19,5 +22,16 @@ matrix:
     - rvm: jruby
     - rvm: rbx
   fast_finish: true
+  exclude:
+  - rvm: 2.1
+    env: RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
+  - rvm: 2.2
+    env: RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
+  - rvm: 2.3
+    env: RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
+  - rvm: jruby
+    env: RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
+  - rvm: rbx
+    env: RUBYOPT="${RUBYOPT} --enable-frozen-string-literal"
 cache: bundler
 script: "rake"

--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -50,14 +50,14 @@ module Roadie
       @html = html
       @asset_providers = ProviderList.wrap(FilesystemProvider.new)
       @external_asset_providers = ProviderList.empty
-      @css = ""
+      @css = String.new("").force_encoding('UTF-8')
       @mode = :html
     end
 
     # Append additional CSS to the document's internal stylesheet.
     # @param [String] new_css
     def add_css(new_css)
-      @css << "\n\n" << new_css
+      @css << "\n\n" + new_css
     end
 
     # Transform the input HTML as a full document and returns the processed

--- a/lib/roadie/errors.rb
+++ b/lib/roadie/errors.rb
@@ -59,8 +59,8 @@ module Roadie
     # TODO: Remove argument on version 4.0.
     def build_message(extra_message = @extra_message)
       message = %(Could not find stylesheet "#{css_name}")
-      message << ": #{extra_message}" if extra_message
-      message << "\nUsed provider:\n#{provider}" if provider
+      message += ": #{extra_message}" if extra_message
+      message += "\nUsed provider:\n#{provider}" if provider
       message
     end
   end
@@ -77,7 +77,7 @@ module Roadie
     def build_message(extra_message)
       message = %(Could not find stylesheet "#{css_name}": #{extra_message}\nUsed providers:\n)
       each_error_row(errors) do |row|
-        message << "\t" << row << "\n"
+        message += "\t" + row + "\n"
       end
       message
     end

--- a/lib/roadie/null_url_rewriter.rb
+++ b/lib/roadie/null_url_rewriter.rb
@@ -7,6 +7,9 @@ module Roadie
   class NullUrlRewriter
     def initialize(generator = nil) end
     def transform_dom(dom) end
-    def transform_css(css) end
+    def transform_css!(css) end
+    def transform_css(css)
+      css
+    end
   end
 end

--- a/lib/roadie/stylesheet.rb
+++ b/lib/roadie/stylesheet.rb
@@ -6,7 +6,7 @@ module Roadie
   # @attr_reader [String] name the name of the stylesheet ("stylesheets/main.css", "Admin user styles", etc.). The name of the stylesheet will be visible if any errors occur.
   # @attr_reader [Array<StyleBlock>] blocks
   class Stylesheet
-    BOM = "\xEF\xBB\xBF".force_encoding('UTF-8').freeze
+    BOM = String.new("\xEF\xBB\xBF").force_encoding('UTF-8').freeze
 
     attr_reader :name, :blocks
 

--- a/lib/roadie/url_rewriter.rb
+++ b/lib/roadie/url_rewriter.rb
@@ -40,8 +40,23 @@ module Roadie
     #
     # @param [String] css the css to mutate
     # @return [nil] css is mutated
-    def transform_css(css)
+    def transform_css!(css)
       css.gsub!(CSS_URL_REGEXP) do
+        matches = Regexp.last_match
+        "url(#{matches[:quote]}#{generate_url(matches[:url])}#{matches[:quote]})"
+      end
+    end
+
+    # Transforms passed CSS, rewriting url() directives.
+    #
+    # This will make all URLs inside url() absolute.
+    #
+    # The transformed CSS is returned, the passed string is kept intact.
+    #
+    # @param [String] css the css to mutate
+    # @return [nil] css is mutated
+    def transform_css(css)
+      css.gsub(CSS_URL_REGEXP) do
         matches = Regexp.last_match
         "url(#{matches[:quote]}#{generate_url(matches[:url])}#{matches[:quote]})"
       end
@@ -81,8 +96,7 @@ module Roadie
       # We need to use a setter for Nokogiri to detect the string mutation.
       # If nokogiri used "dumber" data structures, this would all be redundant.
       css = element["style"]
-      transform_css css
-      element["style"] = css
+      element["style"] = transform_css(css)
     end
   end
 end

--- a/spec/lib/roadie/net_http_provider_spec.rb
+++ b/spec/lib/roadie/net_http_provider_spec.rb
@@ -18,13 +18,13 @@ module Roadie
       invalid_name: "http://example.com/red.css"
     ) do
       before do
-        stub_request(:get, "http://example.com/green.css").and_return(body: "p { color: green; }")
+        stub_request(:get, "http://example.com/green.css").and_return(body: String.new("p { color: green; }"))
         stub_request(:get, "http://example.com/red.css").and_return(status: 404, body: "Not here!")
       end
     end
 
     it "can download over HTTPS" do
-      stub_request(:get, "https://example.com/style.css").and_return(body: "p { color: green; }")
+      stub_request(:get, "https://example.com/style.css").and_return(body: String.new("p { color: green; }"))
       expect {
         NetHttpProvider.new.find_stylesheet!("https://example.com/style.css")
       }.to_not raise_error
@@ -37,7 +37,7 @@ module Roadie
       # asset inlining, but the scheme-less URL implies that there should exist
       # both a HTTP and a HTTPS endpoint. Let's take the secure one in that
       # case!
-      stub_request(:get, "https://example.com/style.css").and_return(body: "p { color: green; }")
+      stub_request(:get, "https://example.com/style.css").and_return(body: String.new("p { color: green; }"))
       expect {
         NetHttpProvider.new.find_stylesheet!("//example.com/style.css")
       }.to_not raise_error
@@ -48,7 +48,7 @@ module Roadie
       # (US-ASCII). The headers will indicate what charset the client should
       # use when trying to make sense of these bytes.
       stub_request(:get, url).and_return(
-        body: %(p::before { content: "l\xF6ve" }).force_encoding("US-ASCII"),
+        body: String.new(%(p::before { content: "l\xF6ve" })).force_encoding("US-ASCII"),
         headers: {"Content-Type" => "text/css;charset=ISO-8859-1"},
       )
 
@@ -64,7 +64,7 @@ module Roadie
 
     it "assumes UTF-8 encoding if server headers do not specify a charset" do
       stub_request(:get, url).and_return(
-        body: %(p::before { content: "Åh nej" }).force_encoding("US-ASCII"),
+        body: String.new(%(p::before { content: "Åh nej" })).force_encoding("US-ASCII"),
         headers: {"Content-Type" => "text/css"},
       )
 
@@ -119,8 +119,8 @@ module Roadie
         whitelisted_url = "http://whitelisted.example.com/style.css"
         other_url       = "http://www.example.com/style.css"
 
-        whitelisted_request = stub_request(:get, whitelisted_url).and_return(body: "x")
-        other_request       = stub_request(:get, other_url).and_return(body: "x")
+        whitelisted_request = stub_request(:get, whitelisted_url).and_return(body: String.new("x"))
+        other_request       = stub_request(:get, other_url).and_return(body: String.new("x"))
 
         expect(provider.find_stylesheet(other_url)).to be_nil
         expect {

--- a/spec/lib/roadie/url_rewriter_spec.rb
+++ b/spec/lib/roadie/url_rewriter_spec.rb
@@ -71,9 +71,10 @@ module Roadie
       it "rewrites all url() directives" do
         expect(generator).to receive(:generate_url).with("some/path.jpg").and_return "http://foo.com/image.jpg"
         css = "body { background: top url(some/path.jpg) #eee; }"
+
         expect {
-          rewriter.transform_css css
-        }.to change { css }.to "body { background: top url(http://foo.com/image.jpg) #eee; }"
+          expect(rewriter.transform_css(css)).to eq "body { background: top url(http://foo.com/image.jpg) #eee; }"
+        }.not_to change { css }
       end
 
       it "correctly identifies URLs with single quotes" do

--- a/spec/shared_examples/url_rewriter.rb
+++ b/spec/shared_examples/url_rewriter.rb
@@ -14,10 +14,17 @@ shared_examples_for "url rewriter" do
     expect(subject.transform_dom(dom)).to be_nil
   end
 
-  it "has a #transform_css(css) method that returns nil" do
+  it "has a #transform_css!(css) method that returns nil" do
+    expect(subject).to respond_to(:transform_css!)
+    expect(subject.method(:transform_css!).arity).to eq(1)
+
+    expect(subject.transform_css!(String.new())).to be_nil
+  end
+
+  it "has a #transform_css(css) method that returns the transformed css" do
     expect(subject).to respond_to(:transform_css)
     expect(subject.method(:transform_css).arity).to eq(1)
 
-    expect(subject.transform_css("")).to be_nil
+    expect(subject.transform_css("")).to eq("")
   end
 end


### PR DESCRIPTION
A proposal PR to make roadie compatible with frozen string literals.

Since Ruby 2.3 it is possible to make the string literals frozen by default.

There are rumors that ruby 3 will have this option on by default.

Inspired by https://freelancing-gods.com/2017/07/27/friendly-frozen-string-literals.html