### PR TITLE
Update nokogiri to 1.8.5 ~ CVE-2018-14404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ rvm:
   - jruby
   - rbx
 before_install:
-  - gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
-  - gem install bundler
+  - gem install bundler -v '1.17.3'
 matrix:
   allow_failures:
     # Rubinius and JRuby have a lot of trouble and no large following, so I'm going to

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9"
 
-  s.add_dependency 'nokogiri', '~> 1.5'
+  s.add_dependency 'nokogiri', '~> 1.8.5'
   s.add_dependency 'css_parser', '~> 1.4'
 
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9"
 
-  s.add_dependency 'nokogiri', '~> 1.8.5'
+  s.add_dependency 'nokogiri', '~> 1.8'
   s.add_dependency 'css_parser', '~> 1.4'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
The current version of nokogiri (1.5) is vulnerable for `CVE-2018-14404` and `CVE-2018-14567`.
A solution for that is update the nokogiri version to `1.8.5` where this fix was already implemented.

References:
https://github.com/sparklemotion/nokogiri/issues/1785
https://rubysec.com/advisories/nokogiri-CVE-2018-14404

*UPD*: Ruby with versions `2.1` and `2.2` are not supported by bundle version 2+, so I specified the exact version in the travis.ci for the build to be working. Also, `gem update --system` seems not be needed anymore for ruby version `2.5.0`.

cc @Mange 