### PR TITLE
ignore nonfilesystem hrefs

### DIFF
--- a/lib/roadie/filesystem_provider.rb
+++ b/lib/roadie/filesystem_provider.rb
@@ -40,7 +40,9 @@ module Roadie
     private
     def build_file_path(name)
       raise InsecurePathError, name if name.include?("..")
-      File.join(@path, name[/^([^?]+)/])
+      return "" unless (filename = name[/^([^?]+)/])
+
+      File.join(@path, filename)
     end
   end
 end

--- a/spec/lib/roadie/filesystem_provider_spec.rb
+++ b/spec/lib/roadie/filesystem_provider_spec.rb
@@ -71,5 +71,14 @@ module Roadie
         end
       end
     end
+
+    describe "ignore link hrefs which are not on filesystem" do
+      # <link rel="stylesheet" href="?__debugger__=yes&amp;cmd=resource&amp;f=style.css" type="text/css">
+      it 'do not raise TypeError' do
+        expect {
+          provider.find_stylesheet!("?__debugger__=yes&amp;cmd=resource&amp;f=style.css")
+        }.to raise_error CssNotFound
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi,
we have situation that our outgoing mails contains some part of HTML page which contains a link to  stylesheets in query string form
```html
<link rel="stylesheet" href="?__debugger__=yes&amp;cmd=resource&amp;f=style.css" type="text/css">
```
Roadie raise error
```
TypeError: no implicit conversion of nil into String
```
in `build_file_path` method. 

I change this method to prevent this exception. `find_stylesheet!` will raise CssNotFound when no real CSS file exist in href.
