### PR TITLE
Update markup improver to support empty string

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v3.4.0...master)
 
-Nothing yet.
+* Gracefully handle empty string email body, such as those provided by `ActionMailer::Base::NullMail` objects
 
 ### 3.5.0
 

--- a/lib/roadie/markup_improver.rb
+++ b/lib/roadie/markup_improver.rb
@@ -25,6 +25,7 @@ module Roadie
     # @return [nil] passed DOM will be mutated
     def improve
       ensure_doctype_present
+      ensure_html_element_present
       head = ensure_head_element_present
       ensure_declared_charset head
     end
@@ -46,6 +47,12 @@ module Roadie
     def uses_buggy_jruby?
       # No reason to check for version yet since no existing version has a fix.
       defined?(JRuby)
+    end
+
+    def ensure_html_element_present
+      return if dom.at_xpath('html')
+      html = Nokogiri::XML::Node.new 'html', dom
+      dom << html
     end
 
     def ensure_head_element_present

--- a/spec/lib/roadie/markup_improver_spec.rb
+++ b/spec/lib/roadie/markup_improver_spec.rb
@@ -36,6 +36,7 @@ module Roadie
 
     describe "basic HTML structure" do
       it "inserts a <html> element as the root" do
+        expect(improve("")).to have_selector("html")
         expect(improve("<h1>Hey!</h1>")).to have_selector("html h1")
         expect(improve("<html></html>").css('html').size).to eq(1)
       end


### PR DESCRIPTION
In the event that an `ActionMailer::Base::NullMail` object is provided, the body will be an empty string. This would result in the same issue as described in https://github.com/Mange/roadie/issues/126. My solution is to ensure that an `<html>` element exists by creating one in the event that we can't find one via xpath.