### PR TITLE
Support frozen string literals, drop Ruby <2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  DisabledByDefault: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,0 @@
-AllCops:
-  DisabledByDefault: true
-  TargetRubyVersion: 2.3
-
-Style/FrozenStringLiteralComment:
-  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.3
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - jruby
   - rbx
 before_install:

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v3.5.1...master)
 
-* Nothing yet.
+* Add support for frozen string literals
 
 ### 3.5.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,9 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v3.5.1...master)
 
-* Add support for frozen string literals
+* Drop support for Ruby 2.1, 2.2, and 2.3 and
+  add support for frozen string literals and Ruby 2.6 - [adamkiczula (Adam
+  Kiczula)](https://github.com/adamkiczula) (#164)
 
 ### 3.5.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 # encoding: utf-8
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 Bundler::GemHelper.install_tasks

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'bundler/setup'

--- a/lib/roadie.rb
+++ b/lib/roadie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
 end
 

--- a/lib/roadie/asset_provider.rb
+++ b/lib/roadie/asset_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # This module can be included in your own code to help you implement the
   # standard behavior for asset providers.

--- a/lib/roadie/asset_scanner.rb
+++ b/lib/roadie/asset_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   #

--- a/lib/roadie/cached_provider.rb
+++ b/lib/roadie/cached_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api public
   # The {CachedProvider} wraps another provider (or {ProviderList}) and caches

--- a/lib/roadie/deduplicator.rb
+++ b/lib/roadie/deduplicator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   class Deduplicator
     def self.apply(input)

--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -52,14 +52,14 @@ module Roadie
       @html = html
       @asset_providers = ProviderList.wrap(FilesystemProvider.new)
       @external_asset_providers = ProviderList.empty
-      @css = ""
+      @css = +""
       @mode = :html
     end
 
     # Append additional CSS to the document's internal stylesheet.
     # @param [String] new_css
     def add_css(new_css)
-      @css << "\n\n" << new_css
+      @css += "\n\n" + new_css
     end
 
     # Transform the input HTML as a full document and returns the processed

--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -59,7 +59,7 @@ module Roadie
     # Append additional CSS to the document's internal stylesheet.
     # @param [String] new_css
     def add_css(new_css)
-      @css += "\n\n" + new_css
+      @css << "\n\n" << new_css
     end
 
     # Transform the input HTML as a full document and returns the processed

--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # The main entry point for Roadie. A document represents a working unit and
   # is built with the input HTML and the configuration options you need.

--- a/lib/roadie/errors.rb
+++ b/lib/roadie/errors.rb
@@ -60,9 +60,9 @@ module Roadie
     # Redundant method argument is to keep API compatability without major version bump.
     # TODO: Remove argument on version 4.0.
     def build_message(extra_message = @extra_message)
-      message = %(Could not find stylesheet "#{css_name}")
-      message += ": #{extra_message}" if extra_message
-      message += "\nUsed provider:\n#{provider}" if provider
+      message = +%(Could not find stylesheet "#{css_name}")
+      message << ": #{extra_message}" if extra_message
+      message << "\nUsed provider:\n#{provider}" if provider
       message
     end
   end
@@ -77,9 +77,9 @@ module Roadie
 
     private
     def build_message(extra_message)
-      message = %(Could not find stylesheet "#{css_name}": #{extra_message}\nUsed providers:\n)
+      message = +%(Could not find stylesheet "#{css_name}": #{extra_message}\nUsed providers:\n)
       each_error_row(errors) do |row|
-        message += "\t" + row + "\n"
+        message << "\t" << row << "\n"
       end
       message
     end

--- a/lib/roadie/errors.rb
+++ b/lib/roadie/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # Base class for all Roadie errors. Rescue this if you want to catch errors
   # from Roadie.

--- a/lib/roadie/errors.rb
+++ b/lib/roadie/errors.rb
@@ -61,8 +61,8 @@ module Roadie
     # TODO: Remove argument on version 4.0.
     def build_message(extra_message = @extra_message)
       message = %(Could not find stylesheet "#{css_name}")
-      message << ": #{extra_message}" if extra_message
-      message << "\nUsed provider:\n#{provider}" if provider
+      message += ": #{extra_message}" if extra_message
+      message += "\nUsed provider:\n#{provider}" if provider
       message
     end
   end
@@ -79,7 +79,7 @@ module Roadie
     def build_message(extra_message)
       message = %(Could not find stylesheet "#{css_name}": #{extra_message}\nUsed providers:\n)
       each_error_row(errors) do |row|
-        message << "\t" << row << "\n"
+        message += "\t" + row + "\n"
       end
       message
     end

--- a/lib/roadie/filesystem_provider.rb
+++ b/lib/roadie/filesystem_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # Asset provider that looks for files on your local filesystem.
   #

--- a/lib/roadie/inliner.rb
+++ b/lib/roadie/inliner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'nokogiri'
 require 'uri'

--- a/lib/roadie/markup_improver.rb
+++ b/lib/roadie/markup_improver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   # Class that improves the markup of a HTML DOM tree

--- a/lib/roadie/net_http_provider.rb
+++ b/lib/roadie/net_http_provider.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'set'

--- a/lib/roadie/net_http_provider.rb
+++ b/lib/roadie/net_http_provider.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'set'
 require 'uri'
 require 'net/http'

--- a/lib/roadie/null_provider.rb
+++ b/lib/roadie/null_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # An asset provider that returns empty stylesheets for any name.
   #

--- a/lib/roadie/null_url_rewriter.rb
+++ b/lib/roadie/null_url_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   # Null Object for the URL rewriter role.

--- a/lib/roadie/null_url_rewriter.rb
+++ b/lib/roadie/null_url_rewriter.rb
@@ -9,6 +9,8 @@ module Roadie
   class NullUrlRewriter
     def initialize(generator = nil) end
     def transform_dom(dom) end
-    def transform_css(css) end
+    def transform_css(css)
+      css
+    end
   end
 end

--- a/lib/roadie/path_rewriter_provider.rb
+++ b/lib/roadie/path_rewriter_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api public
   # This provider acts a bit like a pipeline in normal UNIX parlour by enabling

--- a/lib/roadie/provider_list.rb
+++ b/lib/roadie/provider_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Roadie

--- a/lib/roadie/rspec.rb
+++ b/lib/roadie/rspec.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'roadie/rspec/asset_provider'
 require 'roadie/rspec/cache_store'

--- a/lib/roadie/rspec/asset_provider.rb
+++ b/lib/roadie/rspec/asset_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for "roadie asset provider" do |options|
   valid_name = options[:valid_name] or raise "You must provide a :valid_name option to the shared examples"
   invalid_name = options[:invalid_name] or raise "You must provide an :invalid_name option to the shared examples"

--- a/lib/roadie/rspec/cache_store.rb
+++ b/lib/roadie/rspec/cache_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for "roadie cache store" do
   it "allows storing Stylesheets" do
     stylesheet = Roadie::Stylesheet.new("foo.css", "body { color: green; }")

--- a/lib/roadie/selector.rb
+++ b/lib/roadie/selector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   #

--- a/lib/roadie/style_attribute_builder.rb
+++ b/lib/roadie/style_attribute_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   class StyleAttributeBuilder
     def initialize

--- a/lib/roadie/style_block.rb
+++ b/lib/roadie/style_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Roadie

--- a/lib/roadie/style_property.rb
+++ b/lib/roadie/style_property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   # Domain object for a CSS property such as "color: red !important".

--- a/lib/roadie/stylesheet.rb
+++ b/lib/roadie/stylesheet.rb
@@ -8,7 +8,7 @@ module Roadie
   # @attr_reader [String] name the name of the stylesheet ("stylesheets/main.css", "Admin user styles", etc.). The name of the stylesheet will be visible if any errors occur.
   # @attr_reader [Array<StyleBlock>] blocks
   class Stylesheet
-    BOM = "\xEF\xBB\xBF".force_encoding('UTF-8').freeze
+    BOM = (+"\xEF\xBB\xBF").force_encoding('UTF-8').freeze
 
     attr_reader :name, :blocks
 

--- a/lib/roadie/stylesheet.rb
+++ b/lib/roadie/stylesheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # Domain object that represents a stylesheet (from disc, perhaps).
   #

--- a/lib/roadie/url_generator.rb
+++ b/lib/roadie/url_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Roadie

--- a/lib/roadie/url_rewriter.rb
+++ b/lib/roadie/url_rewriter.rb
@@ -37,13 +37,12 @@ module Roadie
     #
     # This will make all URLs inside url() absolute.
     #
-    # [nil] is returned so no one can misunderstand that this method mutates
-    # the passed string.
+    # Copy of CSS that is mutated is returned, passed string is not mutated.
     #
     # @param [String] css the css to mutate
-    # @return [nil] css is mutated
+    # @return [String] copy of css that is mutated
     def transform_css(css)
-      css.gsub!(CSS_URL_REGEXP) do
+      css.gsub(CSS_URL_REGEXP) do
         matches = Regexp.last_match
         "url(#{matches[:quote]}#{generate_url(matches[:url])}#{matches[:quote]})"
       end
@@ -83,8 +82,7 @@ module Roadie
       # We need to use a setter for Nokogiri to detect the string mutation.
       # If nokogiri used "dumber" data structures, this would all be redundant.
       css = element["style"]
-      transform_css css
-      element["style"] = css
+      element["style"] = transform_css(css)
     end
   end
 end

--- a/lib/roadie/url_rewriter.rb
+++ b/lib/roadie/url_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   # @api private
   #

--- a/lib/roadie/utils.rb
+++ b/lib/roadie/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roadie
   module Utils
     # @api private

--- a/lib/roadie/version.rb
+++ b/lib/roadie/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+
 module Roadie
   VERSION = "3.5.1"
 end

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
-  s.add_development_dependency 'rubocop', '0.64.0'
   s.add_development_dependency 'webmock', '~> 3.0'
 
   s.extra_rdoc_files = %w[README.md Changelog.md]

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -16,13 +16,14 @@ Gem::Specification.new do |s|
   s.description = %q{Roadie tries to make sending HTML emails a little less painful by inlining stylesheets and rewriting relative URLs for you.}
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_dependency 'nokogiri', '~> 1.8'
   s.add_dependency 'css_parser', '~> 1.4'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
+  s.add_development_dependency 'rubocop', '0.75.0'
   s.add_development_dependency 'webmock', '~> 3.0'
 
   s.extra_rdoc_files = %w[README.md Changelog.md]

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
-  s.add_development_dependency 'rubocop', '0.75.0'
+  s.add_development_dependency 'rubocop', '0.64.0'
   s.add_development_dependency 'webmock', '~> 3.0'
 
   s.extra_rdoc_files = %w[README.md Changelog.md]

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # roadie.gemspec
 # -*- encoding: utf-8 -*-
 
@@ -24,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
+  s.add_development_dependency 'rubocop', '0.75.0'
   s.add_development_dependency 'webmock', '~> 3.0'
 
   s.extra_rdoc_files = %w[README.md Changelog.md]

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # roadie.gemspec
 # -*- encoding: utf-8 -*-
 

--- a/spec/hash_as_cache_store_spec.rb
+++ b/spec/hash_as_cache_store_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "roadie/rspec"
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe "Roadie functionality" do

--- a/spec/lib/roadie/asset_scanner_spec.rb
+++ b/spec/lib/roadie/asset_scanner_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/asset_scanner_spec.rb
+++ b/spec/lib/roadie/asset_scanner_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/cached_provider_spec.rb
+++ b/spec/lib/roadie/cached_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 require 'shared_examples/asset_provider'

--- a/spec/lib/roadie/css_not_found_spec.rb
+++ b/spec/lib/roadie/css_not_found_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/deduplicator_spec.rb
+++ b/spec/lib/roadie/deduplicator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Roadie

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/filesystem_provider_spec.rb
+++ b/spec/lib/roadie/filesystem_provider_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/filesystem_provider_spec.rb
+++ b/spec/lib/roadie/filesystem_provider_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 require 'shared_examples/asset_provider'

--- a/spec/lib/roadie/inliner_spec.rb
+++ b/spec/lib/roadie/inliner_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/inliner_spec.rb
+++ b/spec/lib/roadie/inliner_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/markup_improver_spec.rb
+++ b/spec/lib/roadie/markup_improver_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/markup_improver_spec.rb
+++ b/spec/lib/roadie/markup_improver_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/net_http_provider_spec.rb
+++ b/spec/lib/roadie/net_http_provider_spec.rb
@@ -20,13 +20,13 @@ module Roadie
       invalid_name: "http://example.com/red.css"
     ) do
       before do
-        stub_request(:get, "http://example.com/green.css").and_return(body: "p { color: green; }")
+        stub_request(:get, "http://example.com/green.css").and_return(body: +"p { color: green; }")
         stub_request(:get, "http://example.com/red.css").and_return(status: 404, body: "Not here!")
       end
     end
 
     it "can download over HTTPS" do
-      stub_request(:get, "https://example.com/style.css").and_return(body: "p { color: green; }")
+      stub_request(:get, "https://example.com/style.css").and_return(body: +"p { color: green; }")
       expect {
         NetHttpProvider.new.find_stylesheet!("https://example.com/style.css")
       }.to_not raise_error
@@ -39,7 +39,7 @@ module Roadie
       # asset inlining, but the scheme-less URL implies that there should exist
       # both a HTTP and a HTTPS endpoint. Let's take the secure one in that
       # case!
-      stub_request(:get, "https://example.com/style.css").and_return(body: "p { color: green; }")
+      stub_request(:get, "https://example.com/style.css").and_return(body: +"p { color: green; }")
       expect {
         NetHttpProvider.new.find_stylesheet!("//example.com/style.css")
       }.to_not raise_error
@@ -50,7 +50,7 @@ module Roadie
       # (US-ASCII). The headers will indicate what charset the client should
       # use when trying to make sense of these bytes.
       stub_request(:get, url).and_return(
-        body: %(p::before { content: "l\xF6ve" }).force_encoding("US-ASCII"),
+        body: (+%(p::before { content: "l\xF6ve" })).force_encoding("US-ASCII"),
         headers: {"Content-Type" => "text/css;charset=ISO-8859-1"},
       )
 
@@ -66,7 +66,7 @@ module Roadie
 
     it "assumes UTF-8 encoding if server headers do not specify a charset" do
       stub_request(:get, url).and_return(
-        body: %(p::before { content: "Åh nej" }).force_encoding("US-ASCII"),
+        body: (+%(p::before { content: "Åh nej" })).force_encoding("US-ASCII"),
         headers: {"Content-Type" => "text/css"},
       )
 
@@ -121,8 +121,8 @@ module Roadie
         whitelisted_url = "http://whitelisted.example.com/style.css"
         other_url       = "http://www.example.com/style.css"
 
-        whitelisted_request = stub_request(:get, whitelisted_url).and_return(body: "x")
-        other_request       = stub_request(:get, other_url).and_return(body: "x")
+        whitelisted_request = stub_request(:get, whitelisted_url).and_return(body: +"x")
+        other_request       = stub_request(:get, other_url).and_return(body: +"x")
 
         expect(provider.find_stylesheet(other_url)).to be_nil
         expect {

--- a/spec/lib/roadie/net_http_provider_spec.rb
+++ b/spec/lib/roadie/net_http_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 require 'shared_examples/asset_provider'

--- a/spec/lib/roadie/null_provider_spec.rb
+++ b/spec/lib/roadie/null_provider_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/null_provider_spec.rb
+++ b/spec/lib/roadie/null_provider_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples/asset_provider'
 

--- a/spec/lib/roadie/null_url_rewriter_spec.rb
+++ b/spec/lib/roadie/null_url_rewriter_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/null_url_rewriter_spec.rb
+++ b/spec/lib/roadie/null_url_rewriter_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples/url_rewriter'
 

--- a/spec/lib/roadie/path_rewriter_provider_spec.rb
+++ b/spec/lib/roadie/path_rewriter_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 require 'shared_examples/asset_provider'

--- a/spec/lib/roadie/provider_list_spec.rb
+++ b/spec/lib/roadie/provider_list_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/provider_list_spec.rb
+++ b/spec/lib/roadie/provider_list_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 

--- a/spec/lib/roadie/selector_spec.rb
+++ b/spec/lib/roadie/selector_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/selector_spec.rb
+++ b/spec/lib/roadie/selector_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/style_attribute_builder_spec.rb
+++ b/spec/lib/roadie/style_attribute_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/style_block_spec.rb
+++ b/spec/lib/roadie/style_block_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/style_block_spec.rb
+++ b/spec/lib/roadie/style_block_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/style_property_spec.rb
+++ b/spec/lib/roadie/style_property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/stylesheet_spec.rb
+++ b/spec/lib/roadie/stylesheet_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/stylesheet_spec.rb
+++ b/spec/lib/roadie/stylesheet_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/test_provider_spec.rb
+++ b/spec/lib/roadie/test_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'roadie/rspec'
 

--- a/spec/lib/roadie/url_generator_spec.rb
+++ b/spec/lib/roadie/url_generator_spec.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/lib/roadie/url_generator_spec.rb
+++ b/spec/lib/roadie/url_generator_spec.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Roadie

--- a/spec/lib/roadie/url_rewriter_spec.rb
+++ b/spec/lib/roadie/url_rewriter_spec.rb
@@ -73,9 +73,8 @@ module Roadie
       it "rewrites all url() directives" do
         expect(generator).to receive(:generate_url).with("some/path.jpg").and_return "http://foo.com/image.jpg"
         css = "body { background: top url(some/path.jpg) #eee; }"
-        expect {
-          rewriter.transform_css css
-        }.to change { css }.to "body { background: top url(http://foo.com/image.jpg) #eee; }"
+        transformed_css = rewriter.transform_css css
+        expect(transformed_css).to eq "body { background: top url(http://foo.com/image.jpg) #eee; }"
       end
 
       it "correctly identifies URLs with single quotes" do

--- a/spec/lib/roadie/url_rewriter_spec.rb
+++ b/spec/lib/roadie/url_rewriter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples/url_rewriter'
 

--- a/spec/lib/roadie/utils_spec.rb
+++ b/spec/lib/roadie/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Roadie

--- a/spec/shared_examples/asset_provider.rb
+++ b/spec/shared_examples/asset_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for "asset provider role" do
   it "responds to #find_stylesheet" do
     expect(subject).to respond_to(:find_stylesheet)

--- a/spec/shared_examples/url_rewriter.rb
+++ b/spec/shared_examples/url_rewriter.rb
@@ -8,7 +8,7 @@ shared_examples_for "url rewriter" do
     }.to_not raise_error
   end
 
-  it "has a #transform_dom(dom) method that returns nil" do
+  it "has a #transform_dom(dom) method that returns the modified string" do
     expect(subject).to respond_to(:transform_dom)
     expect(subject.method(:transform_dom).arity).to eq(1)
 
@@ -16,10 +16,10 @@ shared_examples_for "url rewriter" do
     expect(subject.transform_dom(dom)).to be_nil
   end
 
-  it "has a #transform_css(css) method that returns nil" do
+  it "has a #transform_css(css) method that returns the modified string" do
     expect(subject).to respond_to(:transform_css)
     expect(subject.method(:transform_css).arity).to eq(1)
 
-    expect(subject.transform_css("")).to be_nil
+    expect(subject.transform_css("")).to eq("")
   end
 end

--- a/spec/shared_examples/url_rewriter.rb
+++ b/spec/shared_examples/url_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for "url rewriter" do
   it "is constructed with a generator" do
     generator = double "URL generator"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/collection_matchers'
 require 'webmock/rspec'
 

--- a/spec/support/have_attribute_matcher.rb
+++ b/spec/support/have_attribute_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :have_attribute do |attribute|
   @selector = 'body > *:first'
 

--- a/spec/support/have_node_matcher.rb
+++ b/spec/support/have_node_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :have_node do |selector|
   chain(:with_attributes) { |attributes| @attributes = attributes }
   match do |document|

--- a/spec/support/have_selector_matcher.rb
+++ b/spec/support/have_selector_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :have_selector do |selector|
   match { |document| !document.css(selector).empty? }
   failure_message { "expected document to have selector #{selector.inspect}"}

--- a/spec/support/have_styling_matcher.rb
+++ b/spec/support/have_styling_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :have_styling do |rules|
   normalized_rules = StylingExpectation.new(rules)
 

--- a/spec/support/have_xpath_matcher.rb
+++ b/spec/support/have_xpath_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :have_xpath do |xpath|
   match { |document| !document.xpath(xpath).empty? }
   failure_message { "expected document to have xpath #{xpath.inspect}"}

--- a/spec/support/test_provider.rb
+++ b/spec/support/test_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestProvider
   include Roadie::AssetProvider
 


### PR DESCRIPTION
I saw someone started to do this in https://github.com/Mange/roadie/pull/160 but that PR has been dead almost a year - so I revived it. I hope that's alright