### PR TITLE
Add Ruby 2.7, allow bundler 2.x on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
-sudo: false
 language: ruby
 rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby
   - rbx
 before_install:
-  - gem install bundler -v '1.17.3'
+  - gem install bundler
 matrix:
   allow_failures:
     # Rubinius and JRuby have a lot of trouble and no large following, so I'm going to
@@ -17,4 +17,3 @@ matrix:
     - rvm: rbx
   fast_finish: true
 cache: bundler
-script: "rake"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v4.0.0...master)
 
-Nothing yet.
+* Enhancements
+  * Test with Ruby 2.7 - [aried3r (Anton Rieder)](https://github.com/aried3r) (#167)
 
 ### 4.0.0
 
@@ -387,4 +388,3 @@ Roadie fork!
   * + some other enhancements
 * Deprecations:
   * Removed support for Rails 2.x
-

--- a/README.md
+++ b/README.md
@@ -446,10 +446,10 @@ Build Status
 
 Tested with [Travis CI](http://travis-ci.org) using:
 
-* MRI 2.1
-* MRI 2.2
-* MRI 2.3
 * MRI 2.4
+* MRI 2.5
+* MRI 2.6
+* MRI 2.7
 * JRuby (latest)
 * Rubinius (failures on Rubinius will not fail the build due to a long history of instability in `rbx`)
 

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.8'
   s.add_dependency 'css_parser', '~> 1.4'
 
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rubocop', '0.75.0'


### PR DESCRIPTION
`sudo: false` is deprecated.
`script: rake` is the default.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
https://docs.travis-ci.com/user/languages/ruby/#default-build-script