### PR TITLE
Add AS_XML serializatiion format support

### DIFF
--- a/lib/roadie/document.rb
+++ b/lib/roadie/document.rb
@@ -142,6 +142,7 @@ module Roadie
     # Valid modes:
     #   `:html` (default)
     #   `:xhtml`
+    #   `:xml`
     def mode=(mode)
       if VALID_MODES.include?(mode)
         @mode = mode
@@ -151,7 +152,7 @@ module Roadie
     end
 
     private
-    VALID_MODES = %i[html xhtml].freeze
+    VALID_MODES = %i[html xhtml xml].freeze
     private_constant :VALID_MODES
 
     def stylesheet
@@ -182,6 +183,7 @@ module Roadie
       format = {
         html: save_options::AS_HTML,
         xhtml: save_options::AS_XHTML,
+        xml: save_options::AS_XML,
       }.fetch(mode)
 
       dom.dup.to_html(

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -70,6 +70,9 @@ module Roadie
 
       document.mode = :html
       expect(document.mode).to eq(:html)
+
+      document.mode = :xml
+      expect(document.mode).to eq(:xml)
     end
 
     it "does not allow unknown modes" do
@@ -126,6 +129,21 @@ module Roadie
           expect(document.transform).to include("{{hello}}")
         end
       end
+
+      context "in XML mode" do
+        it "doesn't replace empty tags with self-closed ones" do
+          document = Document.new "<img src='https://google.com/image.png'></img>"
+          document.mode = :xml
+
+          expect(document.transform_partial).to end_with('</img>')
+        end
+
+        it "does not escape curly braces" do
+          document = Document.new "<a href='https://google.com/{{hello}}'>Hello</a>"
+          document.mode = :xml
+          expect(document.transform_partial).to include("{{hello}}")
+        end
+      end
     end
 
     describe "partial transforming" do
@@ -156,6 +174,21 @@ module Roadie
           document = Document.new "<a href='https://google.com/{{hello}}'>Hello</a>"
           document.mode = :xhtml
 
+          expect(document.transform_partial).to include("{{hello}}")
+        end
+      end
+
+      context "in XML mode" do
+        it "doesn't replace empty tags with self-closed ones" do
+          document = Document.new "<img src='https://google.com/image.png'></img>"
+          document.mode = :xml
+
+          expect(document.transform_partial).to end_with('</img>')
+        end
+
+        it "does not escape curly braces" do
+          document = Document.new "<a href='https://google.com/{{hello}}'>Hello</a>"
+          document.mode = :xml
           expect(document.transform_partial).to include("{{hello}}")
         end
       end


### PR DESCRIPTION
Sometimes we need to render html markup as xml. For instance, in my particular case i have to render inlined styles to RSS-feed and don't allowed to use self-closed tags. Tags like `<img src="..." />` broke some strict xml parsers. 