### PR TITLE
Silence messages about ":host" selector

### DIFF
--- a/lib/roadie/selector.rb
+++ b/lib/roadie/selector.rb
@@ -70,6 +70,7 @@ module Roadie
       :-ms-input-placeholder :-moz-placeholder
       :before :after
       :enabled :disabled :checked
+      :host
     ].freeze
 
     def pseudo_element?

--- a/spec/lib/roadie/selector_spec.rb
+++ b/spec/lib/roadie/selector_spec.rb
@@ -27,6 +27,7 @@ module Roadie
         p:enabled
         p:disabled
         p:checked
+        p:host
       ].each do |bad_selector|
         expect(Selector.new(bad_selector)).not_to be_inlinable
       end


### PR DESCRIPTION
Stops warnings with this message:
`Roadie: Got error when looking for ":host" (from "...public/assets/application-<hash>.css" stylesheet): xmlXPathCompOpEval: function host not found`

I based my change on this issue and matching fix: https://github.com/Mange/roadie/issues/68, fixed in https://github.com/Mange/roadie/pull/69.