### PR TITLE
Support passing serialization_options to Nokogiri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v5.0.1...master)
 
-Nothing yet.
+* Support passing serialization options to Nokogiri with `serialization_options=` method -
+  [Dmytro Savochkin](https://github.com/dmytro-savochkin). (#171)
 
 ### 5.0.1
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Your document instance can be configured with several options:
 * `external_asset_providers` - A list of asset providers that are invoked when absolute CSS URLs are referenced. See below.
 * `before_transformation` - A callback run before transformation starts.
 * `after_transformation` - A callback run after transformation is completed.
+* `serialization_options` - An integer bitmap of options passed along to Nokogiri during serialization.
+By default it's `Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS`.
 
 ### Making URLs absolute ###
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -398,6 +398,38 @@ describe "Roadie functionality" do
       expect(actual_result).to eq(expected_result)
     end
 
+    it "adds XML declaration into XHTML with no serialization options prohibiting it" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <head>
+            <title>Greetings</title>
+          </head>
+        </html>
+      HTML
+
+      document.mode = :xhtml
+      document.serialization_options = 0
+      result = document.transform
+
+      expect(result).to match(/\A<\?xml[^>]*?>/i)
+    end
+
+    it "does not add XML declaration into XHTML with serialization options prohibiting it" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <head>
+            <title>Greetings</title>
+          </head>
+        </html>
+      HTML
+
+      document.mode = :xhtml
+      document.serialization_options = Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+      result = document.transform
+
+      expect(result).not_to match(/\A<\?xml[^>]*?>/i)
+    end
+
     describe "if merge_media_queries is set to false" do
       it "doesn't group non-inlineable media queries in the head" do
         document = Roadie::Document.new <<-HTML

--- a/spec/lib/roadie/document_spec.rb
+++ b/spec/lib/roadie/document_spec.rb
@@ -17,6 +17,16 @@ module Roadie
       expect(document.url_options).to eq({host: "foo.bar"})
     end
 
+    it "has an accessor for serialization options" do
+      serialization_options = Nokogiri::XML::Node::SaveOptions::FORMAT |
+        Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS
+      document.serialization_options = serialization_options
+      expect(document.serialization_options).to eq(serialization_options)
+
+      document.serialization_options = nil
+      expect(document.serialization_options).to eq(0)
+    end
+
     it "has a setting for keeping uninlinable styles" do
       expect(document.keep_uninlinable_css).to be true
       document.keep_uninlinable_css = false


### PR DESCRIPTION
Nokogiri upgrade to 1.11.4 introduced an implicit upgrade of internal libxml2 library to 2.9.12 (for MRI at least).
However on that version of libxml2 they fixed handling of `Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS` flag ([reference](https://github.com/sparklemotion/nokogiri/issues/2324#issuecomment-914288465)) so that it takes effect and forces Nokogiri parser to transform this (for example) `<meta ...>` into this `<meta ...></meta>` when `document.mode = :xhtml` is used.

The problem is that Roadie has these options hardcoded and there is no way for a Roadie user to change them without monkey patching. Hence this PR. It should allow Roadie users to remove `NO_EMPTY_TAGS` to stop Roadie and Nokogiri from transforming empty tags. This PR however is not only about this particular option, it would allow rewriting other options as well: for example, you could remove `Nokogiri::XML::Node::SaveOptions::NO_DECLARATION` to make Roadie and Nokogiri add <?xml ...> declaration tag at the very top of the document.

If this is merged I can prepare a PR for roadie-rails as well.