### PR TITLE
fix: don't strip :root pseudo-class

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v5.2.0...master)
 
+* Don't strip `:root` pseudo-class - [Asger Behncke](https://github.com/asgerb) (#173)
+
 ### 5.2.0
 
 [full changelog](https://github.com/Mange/roadie/compare/v5.1.0...v5.2.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v5.2.0...master)
 
-* Don't strip `:root` pseudo-class - [Asger Behncke](https://github.com/asgerb) (#173)
+* Don't strip the [`:root` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) - [Asger Behncke](https://github.com/asgerb) (#173)
 
 ### 5.2.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 [full changelog](https://github.com/Mange/roadie/compare/v5.2.0...master)
 
-* Don't strip the [`:root` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) - [Asger Behncke](https://github.com/asgerb) (#173)
+* Don't strip the [`:root` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) - [Asger Behncke Jacobsen](https://github.com/asgerb) (#173)
 
 ### 5.2.0
 

--- a/lib/roadie/selector.rb
+++ b/lib/roadie/selector.rb
@@ -71,6 +71,7 @@ module Roadie
       :before :after
       :enabled :disabled :checked
       :host
+      :root
     ].freeze
 
     def pseudo_element?

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -67,6 +67,29 @@ describe "Roadie functionality" do
       expect(styles).to include Roadie::Stylesheet.new("", css).to_s
     end
 
+    it "does not strip :root pseudo-class" do
+      document = Roadie::Document.new <<-HTML
+        <html>
+          <head>
+            <title>Hello world!</title>
+          </head>
+          <body>
+            <h1>Hello world!</h1>
+          </body>
+        </html>
+      HTML
+      css = <<-CSS
+        :root { --color: red; }
+      CSS
+      document.add_css css
+
+      result = parse_html document.transform
+      expect(result).to have_selector("html > head > style")
+
+      styles = result.at_css("html > head > style").text
+      expect(styles).to include Roadie::Stylesheet.new("", css).to_s
+    end
+
     it "can be configured to skip styles that cannot be inlined" do
       document = Roadie::Document.new <<-HTML
         <html>


### PR DESCRIPTION
This PR adds the [:root pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root) to `BAD_PSEUDO_FUNCTIONS`, so it doesn't get stripped from the output CSS.

I've needed this to retain custom properties defined for my stylesheets.