### PR TITLE
relax css_parser version requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
             name: css_parser 1.x
           - gemfile: gemfiles/css_parser_2.gemfile
             name: css_parser 2.x
+          - gemfile: gemfiles/css_parser_3.gemfile
+            name: css_parser 3.x
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.css_parser.gemfile }}

--- a/gemfiles/css_parser_3.gemfile
+++ b/gemfiles/css_parser_3.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+eval_gemfile "../Gemfile"
+
+gem "css_parser", "~> 3.0"

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "nokogiri", "~> 1.15"
-  s.add_dependency "css_parser", ">= 1.4", "< 3.0"
+  s.add_dependency "css_parser", ">= 1.4"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.0"

--- a/roadie.gemspec
+++ b/roadie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "nokogiri", "~> 1.15"
-  s.add_dependency "css_parser", ">= 1.4"
+  s.add_dependency "css_parser", ">= 1.4", "< 4.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Allow updating to css_parser >= 3.0.0

Name: css_parser
Version: 2.2.0
CVE: CVE-2026-53727
GHSA: GHSA-9pmc-p236-855h
Criticality: Unknown
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-53727
Title: SSRF and Local File Disclosure in `CssParser::Parser#read_remote_file`
Solution: update to '>= 3.0.0'